### PR TITLE
add_max_files_to_rewrite_option_spark

### DIFF
--- a/api/src/main/java/org/apache/iceberg/actions/RewriteDataFiles.java
+++ b/api/src/main/java/org/apache/iceberg/actions/RewriteDataFiles.java
@@ -78,6 +78,11 @@ public interface RewriteDataFiles
   String MAX_CONCURRENT_FILE_GROUP_REWRITES = "max-concurrent-file-group-rewrites";
 
   int MAX_CONCURRENT_FILE_GROUP_REWRITES_DEFAULT = 5;
+  /**
+   * The max number of files to be rewritten.By default, this value will be null (To rewrite all the
+   * files)
+   */
+  String MAX_FILES_TO_REWRITE = "max-files-to-rewrite";
 
   /**
    * The output file size that this rewrite strategy will attempt to generate when rewriting files.


### PR DESCRIPTION
This is a new option when re-writing data files (Spark Actions) to provide user the ability to limit the number of files re-written to potentially reduce file OPS . This option is named as max-files-to-rewrite which takes a positive integer as an input, truncates the file tasks until the value is reached. In case the table has fewer files than the parameter value, all the files are processed for re-write option. A property check to ensure that no value less than 1 has also been put in place to ensure early failure.

Implementation :

toGroupStream method in RewriteDataFilesSparkAction has been refactored to truncate the list of file scan tasks (and there by files to be processed)
An atomic integer (to ensure consistency in parallel streams) called fileCountRunner is used to update counter as the groupsByPartition is processed in parallel
In case the size of entire fileScanTask list in a partition is > maxFilesToRewrite + fileCountRunner, the fileScanTask list is truncated to only add the files until the maxFilesToRewrite value is reached.
selectedFileGroups is leveraged to hold the final file groups.
Testing :

TestRewriteDataFilesAction::testRewriteMaxFilesOption is written to handle upper bound use case where the value max-files-to-rewrite > total number of files in the table
TestRewriteDataFilesAction::testRewriteMaxFilesOptionEquality is written to handle equality use case where the value max-files-to-rewrite < total number of files in the table and the resulting data files after rewrite are equal to max-files-to-rewrite